### PR TITLE
Fix: io.Copyを採用しメモリ使用量低減

### DIFF
--- a/src/FileRead.go
+++ b/src/FileRead.go
@@ -1,28 +1,15 @@
 package main
 
 import (
-	"io"
 	"log"
-	"os"
 
 	"github.com/sqweek/dialog"
 )
 
-func FileRead() (readfile []byte) {
-	targetfile, err := dialog.File().Load()
+func FileRead() (readfile string) {
+	selectedFile, err := dialog.File().Load()
 	if err != nil {
 		log.Fatal("File Read Error", err)
 	}
-	file, err := os.Open(targetfile)
-	if err != nil {
-		log.Fatal("File Open Error", err)
-	}
-
-	defer file.Close()
-
-	readfile, err = io.ReadAll(file)
-	if err != nil {
-		log.Fatal("File Read Error", err)
-	}
-	return
+	return selectedFile
 }

--- a/src/SHA256.go
+++ b/src/SHA256.go
@@ -2,10 +2,26 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"log"
+	"os"
 )
 
-func hash_sha256(readfile []byte) {
-	hash := sha256.Sum256(readfile)
-	fmt.Println("sha256: " + fmt.Sprintf("%x", hash))
+func hash_sha256(readfile string) {
+	file, err := os.Open(readfile)
+	if err != nil {
+		log.Fatal("File Open Error", err)
+	}
+
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		log.Fatal(err)
+	}
+
+	hashInBytes := hash.Sum(nil)
+	fmt.Println("sha256", hex.EncodeToString(hashInBytes))
 }


### PR DESCRIPTION
ファイルをﾒﾓﾘにすべて読み込むのではなく、io,Copyを使用してストリーミング処理することでメモリ使用量を低減させました。
それに伴いFileRead.goの処理が一部SHA256に移されています。